### PR TITLE
Prefer string templates over concatenation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
         sourceType: 'module',
     },
     rules: {
+        'prefer-template': 'error',
         'prettier/prettier': 'error',
         'no-await-in-loop': 'warn',
         'max-params': ['error', 6],


### PR DESCRIPTION
Not important but I think it's nice

```javascript
// Preferred
const message = `Hello ${user.name}!`;

// Old
const message = 'Hello ' + user.name + '!';
```