### PR TITLE
Fix deploy action and speed up tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Deploy
         uses: hmanzur/actions-aws-eb@v1.0.0
         with:
-          command: 'deploy'
+          command: 'deploy logan-backend-dev'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.EB_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.EB_ACCESS_KEY_SECRET }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Install Lerna
-        run: npm install
-      - name: Bootstrap dependencies
-        run: npm run bootstrap
+      - name: Install dependencies & bootstrap
+        run: |
+          npm ci
+          npm run bootstrap
       - name: Run lint check
         run: npm run lint
       - name: Run tests


### PR DESCRIPTION
`npm ci` is apparently a faster version of `npm install` specifically intended to be used for CI actions like this
And in the deployment script we got an error saying we need to specify the environment, so this should do that