### PR TITLE
Set up some more stuff we'll need for implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4408,6 +4408,17 @@
 				}
 			}
 		},
+		"@reduxjs/toolkit": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.4.0.tgz",
+			"integrity": "sha512-hkxQwVx4BNVRsYdxjNF6cAseRmtrkpSlcgJRr3kLUcHPIAMZAmMJkXmHh/eUEGTMqPzsYpJLM7NN2w9fxQDuGw==",
+			"requires": {
+				"immer": "^7.0.3",
+				"redux": "^4.0.0",
+				"redux-thunk": "^2.3.0",
+				"reselect": "^4.0.0"
+			}
+		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -13877,6 +13888,11 @@
 				"minimatch": "^3.0.4"
 			}
 		},
+		"immer": {
+			"version": "7.0.9",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-7.0.9.tgz",
+			"integrity": "sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A=="
+		},
 		"import-cwd": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -21615,6 +21631,11 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+		},
+		"reselect": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+			"integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
 		},
 		"resolve": {
 			"version": "1.17.0",

--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -14,9 +14,13 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.4.0",
+    "axios": "^0.20.0",
     "gatsby": "^2.24.60",
     "gatsby-plugin-sass": "^2.3.14",
+    "lodash": "^4.17.20",
     "node-sass": "^4.14.1",
+    "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-redux": "^7.2.1",

--- a/services/frontend/src/store/index.js
+++ b/services/frontend/src/store/index.js
@@ -1,7 +1,12 @@
-import { createStore, combineReducers } from 'redux';
+import { combineReducers } from 'redux';
+import { configureStore } from '@reduxjs/toolkit';
 import { devToolsEnhancer } from 'redux-devtools-extension';
 
 const rootReducer = combineReducers({});
-const store = createStore(rootReducer, devToolsEnhancer());
+
+const store = configureStore({
+    reducer: rootReducer,
+    devTools: [devToolsEnhancer()],
+});
 
 export default store;

--- a/services/frontend/src/utils/api.js
+++ b/services/frontend/src/utils/api.js
@@ -1,0 +1,20 @@
+import _ from 'lodash';
+import axios from 'axios';
+
+const BASE_URL = 'http://logan-backend-dev.us-west-2.elasticbeanstalk.com';
+const client = axios.create({
+    baseURL: BASE_URL,
+});
+
+let bearer;
+
+function setBearerToken(token) {
+    if (token) bearer = `Bearer ${token}`;
+    else bearer = undefined;
+
+    _.set(client, 'defaults.headers.common.Authorization', bearer);
+}
+
+export default {
+    setBearerToken,
+};

--- a/services/frontend/src/utils/slice-maker.js
+++ b/services/frontend/src/utils/slice-maker.js
@@ -1,0 +1,56 @@
+import _ from 'lodash';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
+/**
+ * The configuration for an async reducer
+ * @typedef {Object} AsyncReducerConfig
+ * @property {function} fn - The body of the async thunk. This is what actually gets converted into the thunk
+ * @property {function} [begin] - Called when execution begins. This gets converted to an extraReducer
+ * @property {function} [success] - Called if the promise resolves. This gets converted to an extraReducer
+ * @property {function} [failure] - Called if the promise rejects. This gets converted to an extraReducer
+ */
+
+/**
+ * This function simplifies the use of createSlice and createAsyncThunk by allowing you to create everything in one
+ * method call. Using the asyncReducers property, this function will automatically create async thunks for you, and
+ * create extraReducer handlers for them. See the above documentation for how to pass asyncReducers in
+ * @param {Object} config
+ * @param {string} config.name
+ * @param config.initialState
+ * @param {Object} [config.reducers]
+ * @param {Object} [config.extraReducers]
+ * @param {Object.<string, AsyncReducerConfig>} [config.asyncReducers]
+ */
+export default function createAsyncSlice(config) {
+    const asyncReducers = {};
+
+    // Create any async thunks necessary, and store their extraReducer handler for later
+    if (config.asyncReducers) {
+        for (const [name, { fn, ...handlers }] of _.entries(config.asyncReducers)) {
+            asyncReducers[name] = {
+                thunk: createAsyncThunk(`${config.name}/${name}`, fn),
+                handlers,
+            };
+        }
+    }
+
+    const sliceConfig = {
+        name: config.name,
+        initialState: config.initialState,
+        reducers: config.reducers || {},
+        extraReducers: config.extraReducers || {},
+    };
+
+    // Set up thunk handlers as extraReducers
+    for (const { thunk, handlers } of _.values(asyncReducers)) {
+        if (handlers.begin) sliceConfig.extraReducers[thunk.pending] = handlers.begin;
+        if (handlers.success) sliceConfig.extraReducers[thunk.fulfilled] = handlers.success;
+        if (handlers.failure) sliceConfig.extraReducers[thunk.rejected] = handlers.failure;
+    }
+
+    // Return asyncActions as its own property for easy exporting later
+    return {
+        slice: createSlice(sliceConfig),
+        asyncActions: _.mapValues(asyncReducers, 'thunk'),
+    };
+}


### PR DESCRIPTION
Two main changes here are:
1. Use `configureStore` instead of `createStore` to add async middleware to Redux
2. Add a utility function to simplify async actions and reducers for us