### PR TITLE
Fix the cursor jump bug

### DIFF
--- a/services/frontend/src/components/shared/editor.js
+++ b/services/frontend/src/components/shared/editor.js
@@ -53,6 +53,9 @@ class Editor extends React.Component {
 
         this.processChange(changes, prop, e);
 
+        // Update the state in advance, to avoid the cursor jump bug
+        this._applyChangesToState(changes);
+
         this.updateEntityLocal({
             id: this.props[this._id],
             changes,
@@ -63,6 +66,11 @@ class Editor extends React.Component {
 
     processChange(changes, prop, e) {
         changes[prop] = e.target.value;
+    }
+
+    _applyChangesToState(changes) {
+        const updatedEntity = _.merge({}, this.state[this._entity], changes);
+        this.setState({ [this._entity]: updatedEntity });
     }
 
     componentDidMount() {


### PR DESCRIPTION
The issue was occurring because the editor updates the value in the store, which triggers an update (and therefore a rerender), which then updates the state, which triggers another rerender.

So if the value is "Title" and you edit it as "TiXtle", the component will render:
1. Title
2. TiXtle (when you press the key)
3. Title (after the first update)
4. TiXtle (after the second update)

Reference: https://github.com/facebook/react/issues/955