### PR TITLE
Make the deploy action only run once

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,11 @@ on:
       - master
 
 jobs:
+  cancel-previous:
+    - name: Cancel Workflow Action
+      uses: styfle/cancel-workflow-action@0.6.0
+      with:
+        access_token: ${{ github.token }}
   deploy-fe:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
@beasterbro I think we might need to add a GitHub access token in the repo secrets for this to work